### PR TITLE
Raffinerte oidc login

### DIFF
--- a/.idea/runConfigurations/MainTest_med_stepup.xml
+++ b/.idea/runConfigurations/MainTest_med_stepup.xml
@@ -12,7 +12,7 @@
     <option name="PASS_PARENT_ENVS" value="true" />
     <module name="pus-decorator" />
     <envs>
-      <env name="OIDC_STEPUP_URL" value="http://localhost:8080/stepup" />
+      <env name="OIDC_LOGIN_URL" value="http://localhost:8080/stepup" />
     </envs>
     <method />
   </configuration>

--- a/src/main/java/no/nav/pus/decorator/ApplicationServlet.java
+++ b/src/main/java/no/nav/pus/decorator/ApplicationServlet.java
@@ -55,7 +55,7 @@ public class ApplicationServlet extends HttpServlet {
         String fileRequestPattern = "^(.+\\..{1,4})$";
 
         if (!request.getRequestURI().matches(fileRequestPattern)) {
-            String redirectUrl = loginService.getRedirectUrl(request, response).orElse(null);
+            String redirectUrl = loginService.getLoginRedirectUrl(request, response).orElse(null);
             if (redirectUrl != null) {
                 response.sendRedirect(redirectUrl);
             } else {

--- a/src/main/java/no/nav/pus/decorator/login/AuthenticationResource.java
+++ b/src/main/java/no/nav/pus/decorator/login/AuthenticationResource.java
@@ -1,0 +1,50 @@
+package no.nav.pus.decorator.login;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+
+@Path(AuthenticationResource.AUTHENTICATION_RESOURCE_PATH)
+public class AuthenticationResource {
+
+    static final String AUTHENTICATION_RESOURCE_PATH = "/auth";
+    static final String LOGIN_PATH = "/login";
+
+    private final LoginService loginService;
+    private final String contextPath;
+
+    public AuthenticationResource(LoginService loginService, String contextPath) {
+        this.loginService = loginService;
+        this.contextPath = contextPath;
+    }
+
+    @GET
+    public AuthenticationStatusDTO status(
+            @Context HttpServletRequest httpServletRequest,
+            @Context HttpServletResponse httpServletResponse
+    ) {
+        return loginService.getStatus(httpServletRequest, httpServletResponse);
+    }
+
+    @GET
+    @Path(LOGIN_PATH)
+    public Response login(
+            @Context HttpServletRequest httpServletRequest,
+            @Context HttpServletResponse httpServletResponse
+    ) {
+        URI destinationUrl = loginService.getDestinationUrl(httpServletRequest, httpServletResponse).map(URI::create).orElseGet(() -> goHome(httpServletRequest));
+        return Response.temporaryRedirect(destinationUrl).build();
+    }
+
+    private URI goHome(HttpServletRequest httpServletRequest) {
+        return UriBuilder.fromUri(httpServletRequest.getRequestURL().toString())
+                .replacePath(contextPath)
+                .build();
+    }
+
+}

--- a/src/main/java/no/nav/pus/decorator/login/AuthenticationStatusDTO.java
+++ b/src/main/java/no/nav/pus/decorator/login/AuthenticationStatusDTO.java
@@ -1,0 +1,13 @@
+package no.nav.pus.decorator.login;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Date;
+
+@Data
+@Accessors(chain = true)
+public class AuthenticationStatusDTO {
+    public long remainingSeconds;
+    public Date expirationTime;
+}

--- a/src/main/java/no/nav/pus/decorator/login/LoginService.java
+++ b/src/main/java/no/nav/pus/decorator/login/LoginService.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 public interface LoginService {
 
-    Optional<String> getRedirectUrl(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse);
+    AuthenticationStatusDTO getStatus(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse);
+    Optional<String> getLoginRedirectUrl(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse);
+    Optional<String> getDestinationUrl(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse);
 
 }

--- a/src/main/java/no/nav/pus/decorator/login/NoLoginService.java
+++ b/src/main/java/no/nav/pus/decorator/login/NoLoginService.java
@@ -9,8 +9,18 @@ import static java.util.Optional.empty;
 public class NoLoginService implements LoginService {
 
     @Override
-    public Optional<String> getRedirectUrl(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+    public Optional<String> getLoginRedirectUrl(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
         return empty();
+    }
+
+    @Override
+    public Optional<String> getDestinationUrl(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        return empty();
+    }
+
+    @Override
+    public AuthenticationStatusDTO getStatus(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        return null;
     }
 
 }

--- a/src/main/java/no/nav/pus/decorator/login/OidcLoginService.java
+++ b/src/main/java/no/nav/pus/decorator/login/OidcLoginService.java
@@ -1,26 +1,116 @@
 package no.nav.pus.decorator.login;
 
+import lombok.SneakyThrows;
 import no.nav.brukerdialog.security.jaspic.OidcAuthModule;
+import no.nav.common.auth.SsoToken;
+import no.nav.common.auth.Subject;
+import no.nav.pus.decorator.ApplicationConfig;
+import org.jose4j.jwt.ReservedClaimNames;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.time.Duration;
+import java.util.Date;
 import java.util.Optional;
 
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
+import static java.util.Optional.*;
+import static no.nav.sbl.util.StringUtils.notNullOrEmpty;
 
 public class OidcLoginService implements LoginService {
+    private static final long MINIMUM_REMAINING_SECONDS = Duration.ofMinutes(20).getSeconds();
+    private static final String UTF_8 = "UTF-8";
+
+    static final String DESTINATION_COOKIE_NAME = "login_dest";
+    static final String EXPIRATION_TIME_ATTRIBUTE_NAME = ReservedClaimNames.EXPIRATION_TIME;
+
     private final String oidcLoginUrl;
     private final OidcAuthModule oidcAuthModule;
+    private final String contextPath;
 
-    public OidcLoginService(String oidcLoginUrl, OidcAuthModule oidcAuthModule) {
+    public OidcLoginService(String oidcLoginUrl, OidcAuthModule oidcAuthModule, String contextPath) {
         this.oidcLoginUrl = oidcLoginUrl;
         this.oidcAuthModule = oidcAuthModule;
+        this.contextPath = contextPath;
     }
 
     @Override
-    public Optional<String> getRedirectUrl(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
-        return oidcAuthModule.authenticate(httpServletRequest, httpServletResponse).isPresent() ? empty() : of(oidcLoginUrl + "?url=" + httpServletRequest.getRequestURL());
+    public AuthenticationStatusDTO getStatus(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        Number expirationTimeSeconds = authenticate(httpServletRequest, httpServletResponse)
+                .map(Subject::getSsoToken).map(SsoToken::getAttributes)
+                .map(a -> a.get(EXPIRATION_TIME_ATTRIBUTE_NAME))
+                .map(i -> (Number) i)
+                .orElse(0);
+        long expirationTimestamp = expirationTimeSeconds.longValue() * 1000L;
+        long remainingMillis = expirationTimestamp - System.currentTimeMillis();
+        return new AuthenticationStatusDTO()
+                .setExpirationTime(remainingMillis > 0 ? new Date(expirationTimestamp) : null)
+                .setRemainingSeconds(Math.max(remainingMillis / 1000, 0L));
+    }
+
+    @Override
+    public Optional<String> getLoginRedirectUrl(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        if (getStatus(httpServletRequest, httpServletResponse).remainingSeconds < MINIMUM_REMAINING_SECONDS) {
+            Cookie cookie = new Cookie(DESTINATION_COOKIE_NAME, encode(buildDestinationUrl(httpServletRequest)));
+            cookie.setPath("/");
+            httpServletResponse.addCookie(cookie);
+            String returnUrl = buildReturnUrl(httpServletRequest);
+            return of(String.format("%s?url=%s&redirect=%s&force=true",
+                    oidcLoginUrl,
+                    returnUrl,
+                    returnUrl
+            ));
+        } else {
+            return empty();
+        }
+    }
+
+    private String buildDestinationUrl(HttpServletRequest httpServletRequest) {
+        String requestUrl = httpServletRequest.getRequestURL().toString();
+        String queryString = httpServletRequest.getQueryString();
+        return notNullOrEmpty(queryString) ? requestUrl + "?" + queryString : requestUrl;
+    }
+
+    private String buildReturnUrl(HttpServletRequest httpServletRequest) {
+        return UriBuilder.fromUri(httpServletRequest.getRequestURL().toString())
+                .replacePath(contextPath)
+                .path(ApplicationConfig.DEFAULT_API_PATH)
+                .path(AuthenticationResource.AUTHENTICATION_RESOURCE_PATH)
+                .path(AuthenticationResource.LOGIN_PATH)
+                .build()
+                .toString();
+    }
+
+    @Override
+    public Optional<String> getDestinationUrl(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        Cookie[] cookies = httpServletRequest.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (DESTINATION_COOKIE_NAME.equals(cookie.getName())) {
+                    cookie.setMaxAge(0);
+                    httpServletResponse.addCookie(cookie);
+                    return ofNullable(cookie.getValue()).map(OidcLoginService::decode);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Subject> authenticate(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        return oidcAuthModule.authenticate(httpServletRequest, httpServletResponse);
+    }
+
+    @SneakyThrows
+    static String encode(String requestURI) {
+        return URLEncoder.encode(requestURI, UTF_8);
+    }
+
+    @SneakyThrows
+    static String decode(String value) {
+        return URLDecoder.decode(value, UTF_8);
     }
 
 }

--- a/src/test/java/MainTest.java
+++ b/src/test/java/MainTest.java
@@ -29,9 +29,15 @@ public class MainTest {
         setProperty(PUBLIC_PREFIX + "prop2", "content2", PUBLIC);
 
         if (getOptionalProperty(OIDC_LOGIN_URL_PROPERTY_NAME).isPresent()) {
-            ServiceUser azureADClientId = FasitUtils.getServiceUser("aad_b2c_clientid", "veilarbdemo");
-            setProperty(AZUREAD_B2C_DISCOVERY_URL_PROPERTY_NAME, FasitUtils.getBaseUrl("aad_b2c_discovery"), PUBLIC);
+            ServiceUser azureADClientId;
+            if (FasitUtils.usingMock()) {
+                azureADClientId = FasitUtils.getServiceUser("aad_b2c_clientid", "dev-proxy");
+                setProperty(OIDC_LOGIN_URL_PROPERTY_NAME,"http://localhost:8080/mock/azureadb2c/authorize", PUBLIC);
+            } else {
+                azureADClientId = FasitUtils.getServiceUser("aad_b2c_clientid", "veilarbdemo");
+            }
             setProperty(AZUREAD_B2C_EXPECTED_AUDIENCE_PROPERTY_NAME, azureADClientId.username, SECRET);
+            setProperty(AZUREAD_B2C_DISCOVERY_URL_PROPERTY_NAME, FasitUtils.getBaseUrl("aad_b2c_discovery"), PUBLIC);
         }
 
         Main.main(TEST_PORT);

--- a/src/test/java/no/nav/pus/decorator/login/OidcLoginServiceTest.java
+++ b/src/test/java/no/nav/pus/decorator/login/OidcLoginServiceTest.java
@@ -2,33 +2,106 @@ package no.nav.pus.decorator.login;
 
 import no.nav.brukerdialog.security.domain.IdentType;
 import no.nav.brukerdialog.security.jaspic.OidcAuthModule;
+import no.nav.common.auth.SsoToken;
 import no.nav.common.auth.Subject;
+import org.junit.Before;
 import org.junit.Test;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import static java.util.Optional.of;
 import static no.nav.common.auth.SsoToken.oidcToken;
+import static no.nav.pus.decorator.login.OidcLoginService.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.*;
 
 public class OidcLoginServiceTest {
 
+    private static final int EXPIRATION_TIME = Integer.MAX_VALUE;
+
     private OidcAuthModule oidcAuthModule = mock(OidcAuthModule.class);
+    private OidcLoginService oidcLoginService = new OidcLoginService("https://login.nav.no/oidc", oidcAuthModule, "/contextpath");
+    private HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    private HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+    private String requestUrl = "http://app.nav.no/contextpath";
+    private String queryString = "a=b&c=d";
+    private String completeRequestUrl = "http://app.nav.no/contextpath?a=b&c=d";
+    private String requestUrlEncoded = "http%3A%2F%2Fapp.nav.no%2Fcontextpath";
+    private String queryStringEncoded = "a%3Db%26c%3Dd";
+    private String completeRequestUrlEncoded = "http%3A%2F%2Fapp.nav.no%2Fcontextpath%3Fa%3Db%26c%3Dd";
+
+    @Before
+    public void setup() {
+        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer(requestUrl));
+        when(httpServletRequest.getQueryString()).thenReturn(queryString);
+    }
 
     @Test
-    public void getRedirectUrl() {
-        OidcLoginService oidcLoginService = new OidcLoginService("https://login.nav.no/oidc", oidcAuthModule);
-        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
-        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://app.nav.no/contextpath"));
-        HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+    public void getLoginRedirectUrl() {
+        assertThat(oidcLoginService.getLoginRedirectUrl(httpServletRequest, httpServletResponse)).hasValue("https://login.nav.no/oidc" +
+                "?url=http://app.nav.no/contextpath/api/auth/login" + // url: veilarbstepup
+                "&redirect=http://app.nav.no/contextpath/api/auth/login" + // redirect: loginservice
+                "&force=true" // force=true: force stepup in veilarbstepup
+        );
 
-        assertThat(oidcLoginService.getRedirectUrl(httpServletRequest, httpServletResponse)).hasValue("https://login.nav.no/oidc?url=http://app.nav.no/contextpath");
+        Cookie destinationCookie = new Cookie(DESTINATION_COOKIE_NAME, completeRequestUrlEncoded);
+        destinationCookie.setPath("/");
+        verify(httpServletResponse).addCookie(refEq(destinationCookie));
 
-        when(oidcAuthModule.authenticate(httpServletRequest, httpServletResponse)).thenReturn(of(new Subject("uid", IdentType.EksternBruker, oidcToken("token"))));
-        assertThat(oidcLoginService.getRedirectUrl(httpServletRequest, httpServletResponse)).isEmpty();
+        authenticateUser();
+        assertThat(oidcLoginService.getLoginRedirectUrl(httpServletRequest, httpServletResponse)).isEmpty();
     }
+
+    @Test
+    public void getStatus() {
+        assertThat(oidcLoginService.getStatus(httpServletRequest, httpServletResponse)).isEqualTo(new AuthenticationStatusDTO());
+        authenticateUser();
+
+        long expirationTimeMillis = EXPIRATION_TIME * 1000L;
+        AuthenticationStatusDTO status = oidcLoginService.getStatus(httpServletRequest, httpServletResponse);
+        assertThat(status.remainingSeconds).isGreaterThan(1000);
+        assertThat(status.setRemainingSeconds(0)) // ignore remainingSeconds as it is relative
+                .isEqualTo(new AuthenticationStatusDTO().setExpirationTime(new Date(expirationTimeMillis))
+        );
+    }
+
+    @Test
+    public void postLoginRedirectUrl() {
+        assertThat(oidcLoginService.getDestinationUrl(httpServletRequest, httpServletResponse)).isEmpty();
+
+        when(httpServletRequest.getCookies()).thenReturn(new Cookie[]{new Cookie(DESTINATION_COOKIE_NAME, completeRequestUrlEncoded)});
+        assertThat(oidcLoginService.getDestinationUrl(httpServletRequest, httpServletResponse)).isEqualTo(of(completeRequestUrl));
+
+        Cookie expiredDestinationCookie = new Cookie(DESTINATION_COOKIE_NAME, completeRequestUrlEncoded);
+        expiredDestinationCookie.setMaxAge(0);
+        verify(httpServletResponse).addCookie(refEq(expiredDestinationCookie));
+    }
+
+    @Test
+    public void encode_decode() {
+        String example = "http://example.com/a/b/c";
+        String encoded = OidcLoginService.encode(example);
+        String decoded = OidcLoginService.decode(encoded);
+        assertThat(decoded).isEqualTo(example);
+
+        assertThat(encode(requestUrl)).isEqualTo(requestUrlEncoded);
+        assertThat(encode(queryString)).isEqualTo(queryStringEncoded);
+        assertThat(encode(completeRequestUrl)).isEqualTo(completeRequestUrlEncoded);
+    }
+
+    private void authenticateUser() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put(EXPIRATION_TIME_ATTRIBUTE_NAME, EXPIRATION_TIME);
+        SsoToken oidcToken = oidcToken("token", attributes);
+        Subject subject = new Subject("uid", IdentType.EksternBruker, oidcToken);
+        when(oidcAuthModule.authenticate(httpServletRequest, httpServletResponse)).thenReturn(of(subject));
+    }
+
 
 }


### PR DESCRIPTION
 - tilgjengeliggjør gjenværende gyldighet for token under /api/auth
 - krever minst 20 minutter gyldighet for token
 - tar i mot logins på fast path, /api/auth/login, men bruker cookie for
   å redirecte til opprinnelig url