### PR TITLE
Support for hyphens in appnames

### DIFF
--- a/src/main/java/no/nav/pus/decorator/EnvironmentScriptGenerator.java
+++ b/src/main/java/no/nav/pus/decorator/EnvironmentScriptGenerator.java
@@ -13,7 +13,7 @@ public class EnvironmentScriptGenerator {
     public static final String ENVIRONMENT_CONTEXT_PROPERTY_NAME = "ENVIRONMENT_CONTEXT";
     private static final String PUBLIC_PREFIX_PATTERN = "^" + PUBLIC_PREFIX + ".+";
 
-    private final String environmentContext = camelCaselize(getOptionalProperty(ENVIRONMENT_CONTEXT_PROPERTY_NAME).orElseGet(ApplicationConfig::resolveApplicationName));
+    private final String environmentContext = hyphensToUnderscores(getOptionalProperty(ENVIRONMENT_CONTEXT_PROPERTY_NAME).orElseGet(ApplicationConfig::resolveApplicationName));
 
     public String generate() {
         return formatMapAsJs(getEnvironmentVariablesAndSystemProperties());
@@ -29,11 +29,8 @@ public class EnvironmentScriptGenerator {
         return environmentContext + " = window." + environmentContext + " || {};\n" + values;
     }
 
-    private String camelCaselize(final String envContext) {
-        return Arrays.stream(envContext.split("-"))
-                .sorted(Collections.reverseOrder())
-                .reduce((s, r) -> r += Character.toUpperCase(s.charAt(0)) + s.substring(1))
-                .get();
+    private String hyphensToUnderscores(final String envContext) {
+        return envContext.replaceAll("-", "_");
     }
 
     private Map<String, String> getEnvironmentVariablesAndSystemProperties() {

--- a/src/test/java/no/nav/pus/decorator/EnvironmentScriptGeneratorTest.java
+++ b/src/test/java/no/nav/pus/decorator/EnvironmentScriptGeneratorTest.java
@@ -55,10 +55,10 @@ public class EnvironmentScriptGeneratorTest {
     public void resolvePublicEnvironment__with_public_environment_camel_case() {
         setTemporaryProperty("PRIVATE_NOT_INCLUDE", "secret", () -> {
             setTemporaryProperty("PUBLIC_ABC", "abc", () -> {
-                setTemporaryProperty(ENVIRONMENT_CONTEXT_PROPERTY_NAME, "camel-case-property", () -> {
+                setTemporaryProperty(ENVIRONMENT_CONTEXT_PROPERTY_NAME, "property-with-hyphens", () -> {
                     assertThat(new EnvironmentScriptGenerator().generate()).isEqualTo("" +
-                            "camelCaseProperty = window.camelCaseProperty || {};\n" +
-                            "camelCaseProperty['ABC']='abc';\n"
+                            "property_with_hyphens = window.property_with_hyphens || {};\n" +
+                            "property_with_hyphens['ABC']='abc';\n"
                     );
                 });
             });


### PR DESCRIPTION
Appnames like 'dittnav-nais' result in invalid javascript generated:

```
    dittnav-nais = window.dittnav-nais
```