### PR TITLE
Lås maven til versjon 3.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # gjør det mulig å bytte base-image slik at vi får bygd både innenfor og utenfor NAV
 ARG BASE_IMAGE_PREFIX=""
-FROM ${BASE_IMAGE_PREFIX}maven as maven-builder
+FROM ${BASE_IMAGE_PREFIX}maven:3.6.2 as maven-builder
 ADD / /source
 WORKDIR /source
 RUN mvn install -DskipTests


### PR DESCRIPTION
Maven 3.6.3 er ikke kompatibel med maven-war-plugin 2.6