### PR TITLE
[KAIZEN-0] legger til ny-dekorator-shim

### DIFF
--- a/src/main/java/no/nav/pus/decorator/FragmentCreator.java
+++ b/src/main/java/no/nav/pus/decorator/FragmentCreator.java
@@ -17,8 +17,9 @@ import static no.nav.pus.decorator.ConfigurationService.isEnabled;
 
 public class FragmentCreator {
 
-    private static final String BODY_TEMPLATE = readTemplate("/body-template.html");
-    private static final String HEAD_TEMPLATE = readTemplate("/head-template.html");
+    private static final String BODY_TEMPLATE = readFile("/body-template.html");
+    private static final String HEAD_TEMPLATE = readFile("/head-template.html");
+    private static final String NY_DEKORATOR_CSS_SHIM = readFile("/ny-dekorator-styling-shim.html");
     private final String frontendLoggerHtml;
     private final String environmentHtml;
     private final Optional<String> headerFragment;
@@ -58,6 +59,7 @@ public class FragmentCreator {
                 .prepend(this.frontendLoggerHtml)
                 .prepend(this.environmentHtml)
                 .prepend("{{fragment.styles}}{{fragment.scripts}}{{fragment.megamenu-resources}}")
+                .prepend(NY_DEKORATOR_CSS_SHIM)
                 .prepend(HEAD_TEMPLATE);
     }
 
@@ -77,7 +79,7 @@ public class FragmentCreator {
     }
 
     @SneakyThrows
-    static String readTemplate(String uri) {
+    static String readFile(String uri) {
         return IOUtils.toString(DecoratorFilter.class.getResource(uri), Charset.forName("UTF-8"));
     }
 

--- a/src/main/resources/ny-dekorator-styling-shim.html
+++ b/src/main/resources/ny-dekorator-styling-shim.html
@@ -1,0 +1,18 @@
+<style>
+    body {
+        background-color: #efefef;
+        color: #3e3832;
+    }
+
+    .pagewrapper {
+        height: auto;
+        min-height: 100%;
+        margin-bottom: -200px;
+        padding-bottom: 200px;
+    }
+
+    .maincontent {
+        padding-bottom: 60px;
+        padding-top: 30px;
+    }
+</style>

--- a/src/test/java/no/nav/pus/decorator/FragmentCreatorTest.java
+++ b/src/test/java/no/nav/pus/decorator/FragmentCreatorTest.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 
 import static java.util.stream.Collectors.joining;
 import static no.nav.pus.decorator.EnvironmentScriptGenerator.ENVIRONMENT_CONTEXT_PROPERTY_NAME;
-import static no.nav.pus.decorator.FragmentCreator.readTemplate;
+import static no.nav.pus.decorator.FragmentCreator.readFile;
 import static no.nav.sbl.dialogarena.test.SystemProperties.setTemporaryProperty;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,9 +19,9 @@ public class FragmentCreatorTest {
     public void createFragmentTemplate() {
         setTemporaryProperty(ENVIRONMENT_CONTEXT_PROPERTY_NAME, "testapp", () -> {
             FragmentCreator fragmentCreator = new FragmentCreator(decoratorConfig, "testapp");
-            String fragmentTemplate = fragmentCreator.createFragmentTemplate(readTemplate("/fragmentCreatorTest/original.html"));
+            String fragmentTemplate = fragmentCreator.createFragmentTemplate(readFile("/fragmentCreatorTest/original.html"));
             System.out.println(fragmentTemplate);
-            assertThat(normalize(fragmentTemplate)).isEqualTo(normalize(readTemplate("/fragmentCreatorTest/merged.html")));
+            assertThat(normalize(fragmentTemplate)).isEqualTo(normalize(readFile("/fragmentCreatorTest/merged.html")));
         });
     }
 
@@ -30,9 +30,9 @@ public class FragmentCreatorTest {
         setTemporaryProperty(ENVIRONMENT_CONTEXT_PROPERTY_NAME, "testapp", () -> {
             setTemporaryProperty("PUBLIC_MY_PROPERTY", "public_value", () -> {
                 FragmentCreator fragmentCreator = new FragmentCreator(decoratorConfig, "testapp");
-                String fragmentTemplate = fragmentCreator.createFragmentTemplate(readTemplate("/fragmentCreatorTest/original.html"));
+                String fragmentTemplate = fragmentCreator.createFragmentTemplate(readFile("/fragmentCreatorTest/original.html"));
                 System.out.println(fragmentTemplate);
-                assertThat(normalize(fragmentTemplate)).isEqualTo(normalize(readTemplate("/fragmentCreatorTest/mergedWithEnvironment.html")));
+                assertThat(normalize(fragmentTemplate)).isEqualTo(normalize(readFile("/fragmentCreatorTest/mergedWithEnvironment.html")));
             });
         });
     }

--- a/src/test/resources/fragmentCreatorTest/merged.html
+++ b/src/test/resources/fragmentCreatorTest/merged.html
@@ -3,7 +3,25 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" /> {{fragment.styles}}{{fragment.scripts}}{{fragment.megamenu-resources}}
+    <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" />
+    <style>
+        body {
+            background-color: #efefef;
+            color: #3e3832;
+        }
+
+        .pagewrapper {
+            height: auto;
+            min-height: 100%;
+            margin-bottom: -200px;
+            padding-bottom: 200px;
+        }
+
+        .maincontent {
+            padding-bottom: 60px;
+            padding-top: 30px;
+        }
+    </style> {{fragment.styles}}{{fragment.scripts}}{{fragment.megamenu-resources}}
     <script>
         testapp = window.testapp || {};
 

--- a/src/test/resources/fragmentCreatorTest/mergedWithEnvironment.html
+++ b/src/test/resources/fragmentCreatorTest/mergedWithEnvironment.html
@@ -3,7 +3,25 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" /> {{fragment.styles}}{{fragment.scripts}}{{fragment.megamenu-resources}}
+    <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" />
+    <style>
+        body {
+            background-color: #efefef;
+            color: #3e3832;
+        }
+
+        .pagewrapper {
+            height: auto;
+            min-height: 100%;
+            margin-bottom: -200px;
+            padding-bottom: 200px;
+        }
+
+        .maincontent {
+            padding-bottom: 60px;
+            padding-top: 30px;
+        }
+    </style> {{fragment.styles}}{{fragment.scripts}}{{fragment.megamenu-resources}}
     <script>
         testapp = window.testapp || {};
         testapp['MY_PROPERTY']='public_value';


### PR DESCRIPTION
gamle dekoratøren ga oss fortsatt litt styling for layout, e.g `pagewrapper`, `maincontent` og bakgrunnfarge på `body`.
For å gjøre veien over til ny dekoratør enklere legger vi med den stylingen selv, siden pus-decorator er der markup-en også blir lagt til.