### PR TITLE
Hent Azure AD B2C config fra nye loginservice idporten env variabler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,14 @@
             <artifactId>log4j-to-slf4j</artifactId>
             <version>2.13.3</version>
         </dependency>
+
+        <!-- Overskriv nimbus versjon for å fikse NoSuchMethodError -->
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>8.20</version>
+        </dependency>
+
         <dependency>
             <groupId>no.nav.common</groupId>
             <artifactId>json</artifactId>

--- a/src/main/java/no/nav/pus/decorator/login/LoginServiceResolver.java
+++ b/src/main/java/no/nav/pus/decorator/login/LoginServiceResolver.java
@@ -1,10 +1,15 @@
 package no.nav.pus.decorator.login;
 
+import no.nav.brukerdialog.security.domain.IdentType;
 import no.nav.brukerdialog.security.oidc.provider.AzureADB2CConfig;
 import no.nav.common.oidc.OidcTokenValidator;
 import no.nav.pus.decorator.config.Config;
+import no.nav.sbl.util.EnvironmentUtils;
 
 import static java.util.Optional.ofNullable;
+import static no.nav.brukerdialog.security.Constants.AZUREADB2C_OIDC_COOKIE_NAME_SBS;
+import static no.nav.brukerdialog.security.oidc.provider.AzureADB2CConfig.EXTERNAL_USERS_AZUREAD_B2C_DISCOVERY_URL;
+import static no.nav.brukerdialog.security.oidc.provider.AzureADB2CConfig.EXTERNAL_USERS_AZUREAD_B2C_EXPECTED_AUDIENCE;
 
 public class LoginServiceResolver {
 
@@ -15,7 +20,15 @@ public class LoginServiceResolver {
     }
 
     private static LoginService oidcLoginService(AuthConfig authConfig, String contextPath) {
-        AzureADB2CConfig azureADB2CConfig = AzureADB2CConfig.configureAzureAdForExternalUsers();
+        String discoveryUrl = EnvironmentUtils.getRequiredProperty("LOGINSERVICE_IDPORTEN_DISCOVERY_URL", EXTERNAL_USERS_AZUREAD_B2C_DISCOVERY_URL);
+        String expectedAudience = EnvironmentUtils.getRequiredProperty("LOGINSERVICE_IDPORTEN_AUDIENCE", EXTERNAL_USERS_AZUREAD_B2C_EXPECTED_AUDIENCE);
+
+        AzureADB2CConfig azureADB2CConfig = AzureADB2CConfig.builder()
+                .discoveryUrl(discoveryUrl)
+                .expectedAudience(expectedAudience)
+                .tokenName(AZUREADB2C_OIDC_COOKIE_NAME_SBS)
+                .identType(IdentType.EksternBruker)
+                .build();
 
         OidcTokenValidator validator = new OidcTokenValidator(azureADB2CConfig.discoveryUrl, azureADB2CConfig.expectedAudience);
         return new OidcLoginService(authConfig, validator, contextPath);

--- a/src/test/java/no/nav/pus/decorator/ProxyIntegrationTest.java
+++ b/src/test/java/no/nav/pus/decorator/ProxyIntegrationTest.java
@@ -18,10 +18,7 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.glassfish.jersey.client.JerseyClient;
 import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.springframework.util.SocketUtils;
 
 import java.io.File;


### PR DESCRIPTION
Hvis LOGINSERVICE_IDPORTEN_DISCOVERY_URL og LOGINSERVICE_IDPORTEN_AUDIENCE ikke er satt så vil de tidligere AAD_B2C variablene bli brukt.