### PR TITLE
Legg til SslContextFactory i ProxyClient for å støtte SSL-proxy

### DIFF
--- a/src/main/java/no/nav/pus/decorator/proxy/ProxyClient.java
+++ b/src/main/java/no/nav/pus/decorator/proxy/ProxyClient.java
@@ -6,6 +6,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 public class ProxyClient extends HttpClient {
 
     public ProxyClient() {
+        super(new SslContextFactory.Client());
         setRequestBufferSize(8192);
     }
 


### PR DESCRIPTION
Dette løser problemet med `java.lang.NullPointerException: Missing SslContextFactory` ved kall mot HTTPS-lenker gjennom proxyen.