### PR TITLE
GCP-dev/prod subnets i InternalProtectionFilter

### DIFF
--- a/src/main/java/no/nav/pus/decorator/security/InternalProtectionFilter.java
+++ b/src/main/java/no/nav/pus/decorator/security/InternalProtectionFilter.java
@@ -20,7 +20,9 @@ import static no.nav.apiapp.ApiAppServletContextListener.INTERNAL_IS_ALIVE;
 public class InternalProtectionFilter implements Filter {
 
     private static final List<Pattern> SUBNET_IP_PATTERNS = Arrays.asList(
-            Pattern.compile("192\\.168\\.\\d{1,3}\\.\\d{1,3}") // on-prem
+            Pattern.compile("192\\.168\\.\\d{1,3}\\.\\d{1,3}"), // on-prem
+            Pattern.compile("10\\.6\\.\\d{1,3}\\.\\d{1,3}"), // gcp dev
+            Pattern.compile("10\\.7\\.\\d{1,3}\\.\\d{1,3}") // gcp prod
     );
 
     private static final List<String> SAFE_POSTFIXES = new ArrayList<>(asList(

--- a/src/main/java/no/nav/pus/decorator/security/InternalProtectionFilter.java
+++ b/src/main/java/no/nav/pus/decorator/security/InternalProtectionFilter.java
@@ -7,8 +7,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
@@ -17,7 +19,10 @@ import static no.nav.apiapp.ApiAppServletContextListener.INTERNAL_IS_ALIVE;
 @Slf4j
 public class InternalProtectionFilter implements Filter {
 
-    private static final Pattern SUBNET_IP_PATTERN = Pattern.compile("192\\.168\\.\\d{1,3}\\.\\d{1,3}");
+    private static final List<Pattern> SUBNET_IP_PATTERNS = Arrays.asList(
+            Pattern.compile("192\\.168\\.\\d{1,3}\\.\\d{1,3}") // on-prem
+    );
+
     private static final List<String> SAFE_POSTFIXES = new ArrayList<>(asList(
             ".oera.no",
             ".oera-q.local",
@@ -51,9 +56,11 @@ public class InternalProtectionFilter implements Filter {
 
     static boolean isAllowedAccessToInternal(String hostname) {
         return "localhost".equals(hostname) // allow for local development and testing
-                || SUBNET_IP_PATTERN.matcher(hostname).matches() // kubernetes uses subnet ips to access internal endpoints
+                || SUBNET_IP_PATTERNS.stream().anyMatch(pattern -> pattern.matcher(hostname).matches()) // kubernetes uses subnet ips to access internal endpoints
                 || SAFE_POSTFIXES.stream().anyMatch(hostname::endsWith) // allow access from internal addresses
                 ;
+
+
     }
 
     @Override

--- a/src/test/java/no/nav/pus/decorator/security/InternalProtectionFilterTest.java
+++ b/src/test/java/no/nav/pus/decorator/security/InternalProtectionFilterTest.java
@@ -12,6 +12,8 @@ public class InternalProtectionFilterTest {
         assertNoAccess("tjenester.nav.no");
         assertNoAccess("evil.com");
         assertNoAccess("174.148.185.236");
+        assertNoAccess("10.6.81.131");
+        assertNoAccess("10.7.5.123");
 
         assertAccess("192.168.1.1");
         assertAccess("192.168.255.255");

--- a/src/test/java/no/nav/pus/decorator/security/InternalProtectionFilterTest.java
+++ b/src/test/java/no/nav/pus/decorator/security/InternalProtectionFilterTest.java
@@ -12,8 +12,8 @@ public class InternalProtectionFilterTest {
         assertNoAccess("tjenester.nav.no");
         assertNoAccess("evil.com");
         assertNoAccess("174.148.185.236");
-        assertNoAccess("10.6.81.131");
-        assertNoAccess("10.7.5.123");
+        assertNoAccess("10.8.81.131");
+        assertNoAccess("10.5.81.131");
 
         assertAccess("192.168.1.1");
         assertAccess("192.168.255.255");
@@ -23,6 +23,8 @@ public class InternalProtectionFilterTest {
         assertAccess("myapp.nais.preprod.local");
         assertAccess("myapp-q0.nais.oera-q.local");
         assertAccess("localhost");
+        assertAccess("10.6.81.131");
+        assertAccess("10.7.5.123");
     }
 
     @Test


### PR DESCRIPTION
Åpner opp for `10.6.x.x` (gcp-dev) og `10.7.x.x` (gcp-prod) i `InternalProtectionFilter`.