### PR TITLE
f Bruker oppdatert versjon av commons

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pus-decorator comes with much functionality out of the box, but may be deactivat
  - `DISABLE_PROXY`
  - `DISABLE_UNLEASH`
  - `DISABLE_FRONTEND_LOGGER`
+ - `DISABLE_SENSU_METRICS`
 
 BETA:
 Use the environment variabel `GZIP_ENABLED` in the `Dockerfile` to turn on gzipping for files: `ENV GZIP_ENABLED=true`.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.nav.common</groupId>
         <artifactId>mor-pom</artifactId>
-        <version>1.2020.11.16_14.52-3f16e0d8c867</version>
+        <version>1.2021.07.07_10.18-72bd65c546f6</version>
     </parent>
 
     <groupId>no.nav.pus</groupId>


### PR DESCRIPTION
Denne versjonen av commons introduserer 'DISABLE_SENSU_METRICS'-envvariabelet. Ved å sette dette så vil ikke
metrics bli sendt. Nyttig for løsninger som kjører på gcp, hvor influx ikke er satt opp. 