### PR TITLE
Upgrade log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.0</version>
         </dependency>
 
         <!-- Overskriv nimbus versjon for å fikse NoSuchMethodError -->


### PR DESCRIPTION
Bare for å være på den sikre siden i forhold til: 
https://www.lunasec.io/docs/blog/log4j-zero-day/

Denne er såpass alvorlig, så det er veldig viktig at dere sjekker opp appene deres. Løst tatt fra artikkelen Hågen postet:
Er appen min sårbar? Muligens, hvis:
Appen tar inn org.apache.logging.log4j:log4j-api versjon f.o.m 2.0  t.o.m. 2.14.1. Dette gjelder en god del av prosjektene i NAV. Husk at denne kan bli dratt inn av andre biblioteker, og trenger ikke være en direkte avhengighet
Apper benytter log4j-core til logging, og ikke logback eller andre loggbiblioteker.
Hva gjør jeg?
Det er to muligheter akkurat nå
Sett log4j2.formatMsgNoLookups til true  (JVM-argument: -Dlog4j2.formatMsgNoLookups=true)
Oppgrader til log4j-2.15.0