### PR TITLE
Håndtere endring i idporten/loginservice

### DIFF
--- a/src/main/java/no/nav/pus/decorator/login/OidcLoginService.java
+++ b/src/main/java/no/nav/pus/decorator/login/OidcLoginService.java
@@ -1,6 +1,7 @@
 package no.nav.pus.decorator.login;
 
 import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
 import lombok.SneakyThrows;
 import no.nav.brukerdialog.security.domain.IdentType;
@@ -11,6 +12,8 @@ import no.nav.common.oidc.OidcTokenValidator;
 import no.nav.common.oidc.utils.TokenUtils;
 import no.nav.pus.decorator.ApplicationConfig;
 import org.jose4j.jwt.ReservedClaimNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -19,6 +22,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
@@ -33,6 +37,7 @@ public class OidcLoginService implements LoginService {
     private final long minRemainingSeconds;
 
     private static final String UTF_8 = "UTF-8";
+    private static final Logger log = LoggerFactory.getLogger(OidcLoginService.class);
 
     static final String DESTINATION_COOKIE_NAME = "login_dest";
     static final String EXPIRATION_TIME_ATTRIBUTE_NAME = ReservedClaimNames.EXPIRATION_TIME;
@@ -147,7 +152,7 @@ public class OidcLoginService implements LoginService {
 
             SsoToken ssoToken = SsoToken.oidcToken(jwtToken.getParsedString(), jwtToken.getJWTClaimsSet().getClaims());
             Subject subject = new Subject(
-                    TokenUtils.getUid(jwtToken, IdentType.EksternBruker),
+                    getUid(jwtToken),
                     IdentType.EksternBruker,
                     ssoToken
             );
@@ -179,6 +184,28 @@ public class OidcLoginService implements LoginService {
                         .findFirst()
                         .map(Cookie::getValue)
                 );
+    }
+
+    static String getUid(JWT token) throws ParseException {
+        JWTClaimsSet claimsSet = token.getJWTClaimsSet();
+        String pid = getPid(token);
+        String sub = claimsSet.getSubject();
+        if (pid != null) {
+            return pid;
+        } else if (sub != null) {
+            return sub;
+        } else {
+            log.error("Could not extract UID from jwt, pid/sub was empty");
+            return null;
+        }
+    }
+
+    private static String getPid(JWT token) {
+        try {
+            return token.getJWTClaimsSet().getStringClaim("pid");
+        } catch (ParseException e) {
+            return null;
+        }
     }
 
     @SneakyThrows

--- a/src/test/java/no/nav/pus/decorator/login/OidcLoginServiceTest.java
+++ b/src/test/java/no/nav/pus/decorator/login/OidcLoginServiceTest.java
@@ -1,5 +1,7 @@
 package no.nav.pus.decorator.login;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
 import no.nav.brukerdialog.security.domain.IdentType;
 import no.nav.common.auth.SecurityLevel;
 import no.nav.common.auth.SsoToken;
@@ -11,6 +13,7 @@ import org.junit.Test;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.text.ParseException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -104,6 +107,39 @@ public class OidcLoginServiceTest {
         assertThat(encode(requestUrl)).isEqualTo(requestUrlEncoded);
         assertThat(encode(queryString)).isEqualTo(queryStringEncoded);
         assertThat(encode(completeRequestUrl)).isEqualTo(completeRequestUrlEncoded);
+    }
+
+    @Test
+    public void getUid_returns_null_if_missing() throws ParseException {
+        JWTClaimsSet claimset = new JWTClaimsSet
+                .Builder()
+                .build();
+        PlainJWT token = new PlainJWT(claimset);
+
+        assertThat(getUid(token)).isNull();
+    }
+
+    @Test
+    public void getUid_returns_pid_if_it_exist() throws ParseException {
+        JWTClaimsSet claimset = new JWTClaimsSet
+                .Builder()
+                .subject("subvalue")
+                .claim("pid", "pidvalue")
+                .build();
+        PlainJWT token = new PlainJWT(claimset);
+
+        assertThat(getUid(token)).isEqualTo("pidvalue");
+    }
+
+    @Test
+    public void getUid_returns_sub_if_pid_doesnt_exist() throws ParseException {
+        JWTClaimsSet claimset = new JWTClaimsSet
+                .Builder()
+                .subject("subvalue")
+                .build();
+        PlainJWT token = new PlainJWT(claimset);
+
+        assertThat(getUid(token)).isEqualTo("subvalue");
     }
 
     private void authenticateUser() {


### PR DESCRIPTION
Endring i idporten gjør at loginservice vil flytte brukers ident til `pid`. Vi må derfor sjekke dette før vi evt bruker en fallback til `sub`.

Koden for dette er lagt direkte inn i koden istedet for å begynne å oppdatere fellesbibliotek og versjoner i denne appen, siden pus-decorator begynner å nærme seg EOL.
