### PR TITLE
Legge til flere host som kan nå internal endepunkter

### DIFF
--- a/src/main/java/no/nav/pus/decorator/security/InternalProtectionFilter.java
+++ b/src/main/java/no/nav/pus/decorator/security/InternalProtectionFilter.java
@@ -29,7 +29,9 @@ public class InternalProtectionFilter implements Filter {
             ".oera.no",
             ".oera-q.local",
             ".adeo.no",
-            ".preprod.local"
+            ".preprod.local",
+            ".dev.nav.no",
+            ".intern.nav.no"
     ));
 
     @Override

--- a/src/test/java/no/nav/pus/decorator/security/InternalProtectionFilterTest.java
+++ b/src/test/java/no/nav/pus/decorator/security/InternalProtectionFilterTest.java
@@ -22,6 +22,8 @@ public class InternalProtectionFilterTest {
         assertAccess("myapp.nais.adeo.no");
         assertAccess("myapp.nais.preprod.local");
         assertAccess("myapp-q0.nais.oera-q.local");
+        assertAccess("myapp.dev.nav.no");
+        assertAccess("myapp.intern.nav.no");
         assertAccess("localhost");
         assertAccess("10.6.81.131");
         assertAccess("10.7.5.123");


### PR DESCRIPTION
Ref nye ingresser på GCP https://doc.nais.io/clusters/gcp/

Selftest endepunkter under internal blir brukt til: 

" Overvåkingen vi snakker om her går blant annet til Operasjonssentralen, og er et sentralt verktøy for dem for å ha en status på IT-systemene:
https://teamkatalog.nav.no/team/ff49ab30-9eb6-4707-b113-06a3a8f003f4
" 